### PR TITLE
fix: 스크랩 생성 중 날짜 오류로 인해 스크랩 안되는 문제 수정

### DIFF
--- a/src/domains/scrap/repository/articleRepository.js
+++ b/src/domains/scrap/repository/articleRepository.js
@@ -1,11 +1,13 @@
 const { prisma } = require("../../../config/db");
 
 const createArticle = async (articleData, s3Url, keyword = "default") => {
-    return prisma.article.create({
+  const publishedAt = isNaN(new Date(articleData.write_time)) ? new Date() : new Date(articleData.write_time);  
+  
+  return prisma.article.create({
         data: {
             keyword,
             title: articleData.title,
-            publishedAt: new Date(articleData.write_time),
+            publishedAt,
             source: articleData.company,
             content: articleData.short_content,
             imageUrl: s3Url,


### PR DESCRIPTION
Invalid value for argument `publishedAt`: Provided Date object is invalid. Expected Date.
<img width="813" alt="image" src="https://github.com/user-attachments/assets/b35fe9a5-1d88-4938-b713-a18d3b4e7687" />
위 오류로 스크랩이 안되는 문제가 있어 현재 날짜로 해서 저장되도록 임시로 수정했습니다.
